### PR TITLE
fix: prevent command injection in pingHost and traceroute tools

### DIFF
--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -1,10 +1,10 @@
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';  
 import { promisify } from 'node:util';
 import { createConnection } from 'node:net';
 import os from 'node:os';
 import { NetworkConnectivityResult } from '../types.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export const networkTools = {
   getNetworkInterfaces: {
@@ -125,12 +125,12 @@ export const networkTools = {
     },
     handler: async ({ host, count = 4 }: { host: string; count?: number }) => {
       const platform = os.platform();
-      const pingCmd = platform === 'win32' 
-        ? `ping -n ${count} ${host}`
-        : `ping -c ${count} ${host}`;
+      const pingArgs = platform === 'win32'
+      ? ['-n', String(count), host]
+      : ['-c', String(count), host];
 
       try {
-        const { stdout } = await execAsync(pingCmd);
+        const { stdout } = await execFileAsync('ping', pingArgs);
         return {
           content: [{
             type: 'text',
@@ -158,10 +158,10 @@ export const networkTools = {
     },
     handler: async ({ host }: { host: string }) => {
       const platform = os.platform();
-      const cmd = platform === 'win32' ? `tracert ${host}` : `traceroute ${host}`;
+      const file = platform === 'win32' ? 'tracert' : 'traceroute';
 
       try {
-        const { stdout } = await execAsync(cmd);
+       const { stdout } = await execFileAsync(file, [host])
         return {
           content: [{
             type: 'text',


### PR DESCRIPTION
Replace child_process.exec with execFile in the network tools to avoid shell interpretation.

The previous implementation constructed ping and traceroute commands using child_process.exec and interpolated user-controlled input (`host` and `count`) into the command string. Because exec invokes a system shell, specially crafted input containing shell metacharacters could potentially lead to command injection.

This change:

• replaces exec with execFile  
• passes command arguments as arrays instead of string concatenation   
• avoids shell interpretation of user-controlled input  

This prevents potential command injection while preserving the original functionality of the tools.